### PR TITLE
fix SD card module functionality

### DIFF
--- a/lib/AccessControl/AccessManager.cpp
+++ b/lib/AccessControl/AccessManager.cpp
@@ -5,25 +5,36 @@
 #include <SD.h>
 
 const char *const LOG_FORMAT PROGMEM = "%04d-%02d-%02dT%02d:%02d:%02dZ %02X%02X%02X%02X %d%c";
+const int chipSelect = 7;
+const int transistor = 8;
 
 AccessManager::AccessManager(int sdCSPin, int sdMISOActivatePin) : m_sdCSPin(sdCSPin), m_sdMISOActivatePin(sdMISOActivatePin) {}
 
 void AccessManager::init()
 {
     // initialize the pins
-    pinMode(m_sdMISOActivatePin, OUTPUT);
+    Serial.print("\nInitializing SD card...");
 
-    // initialize the SD module
-    activateSDModule();
-    if (!SD.begin(m_sdCSPin))
+    // activate MISO line from transistor
+    digitalWrite(transistor, HIGH);
+
+    // we'll use the initialization code from the utility libraries
+    // since we're just testing if the card is working!
+    if (!SD.begin(SPI_HALF_SPEED, chipSelect))
     {
-        Serial.println(F("SD card initialization failed!"));
-        // fail
-        while (true)
+        Serial.println("initialization failed. Things to check:");
+        Serial.println("* is a card inserted?");
+        Serial.println("* is your wiring correct?");
+        Serial.println("* did you change the chipSelect pin to match your shield or module?");
+        while (1)
             ;
     }
+    else
+    {
+        Serial.println("Wiring is correct and a card is present.");
+    }
 
-    deactivateSDModule();
+    digitalWrite(transistor, LOW);
 }
 
 bool AccessManager::checkAccess(byte *const &detected)

--- a/lib/AccessControl/AccessManager.cpp
+++ b/lib/AccessControl/AccessManager.cpp
@@ -13,7 +13,7 @@ AccessManager::AccessManager(int sdCSPin, int sdMISOActivatePin) : m_sdCSPin(sdC
 void AccessManager::init()
 {
     // initialize the pins
-    Serial.print("\nInitializing SD card...");
+    Serial.print(F("Initializing SD card..."));
 
     // activate MISO line from transistor
     digitalWrite(transistor, HIGH);
@@ -22,16 +22,16 @@ void AccessManager::init()
     // since we're just testing if the card is working!
     if (!SD.begin(SPI_HALF_SPEED, chipSelect))
     {
-        Serial.println("initialization failed. Things to check:");
-        Serial.println("* is a card inserted?");
-        Serial.println("* is your wiring correct?");
-        Serial.println("* did you change the chipSelect pin to match your shield or module?");
+        Serial.println(F("initialization failed. Things to check:"));
+        Serial.println(F("* is a card inserted?"));
+        Serial.println(F("* is your wiring correct?"));
+        Serial.println(F("* did you change the chipSelect pin to match your shield or module?"));
         while (1)
             ;
     }
     else
     {
-        Serial.println("Wiring is correct and a card is present.");
+        Serial.println(F("Wiring is correct and a card is present."));
     }
 
     digitalWrite(transistor, LOW);

--- a/lib/AccessControl/AccessManager.cpp
+++ b/lib/AccessControl/AccessManager.cpp
@@ -5,22 +5,21 @@
 #include <SD.h>
 
 const char *const LOG_FORMAT PROGMEM = "%04d-%02d-%02dT%02d:%02d:%02dZ %02X%02X%02X%02X %d%c";
-const int chipSelect = 7;
-const int transistor = 8;
 
-AccessManager::AccessManager(int sdCSPin, int sdMISOActivatePin) : m_sdCSPin(sdCSPin), m_sdMISOActivatePin(sdMISOActivatePin) {}
-
-void AccessManager::init()
+void AccessManager::init(int sdCSPin, int sdMISOActivatePin)
 {
+    m_sdCSPin = sdCSPin;
+    m_sdMISOActivatePin = sdMISOActivatePin;
+
     // initialize the pins
     Serial.print(F("Initializing SD card..."));
 
     // activate MISO line from transistor
-    digitalWrite(transistor, HIGH);
+    activateSDModule();
 
     // we'll use the initialization code from the utility libraries
     // since we're just testing if the card is working!
-    if (!SD.begin(SPI_HALF_SPEED, chipSelect))
+    if (!SD.begin(SPI_FULL_SPEED, sdCSPin))
     {
         Serial.println(F("initialization failed. Things to check:"));
         Serial.println(F("* is a card inserted?"));
@@ -34,7 +33,7 @@ void AccessManager::init()
         Serial.println(F("Wiring is correct and a card is present."));
     }
 
-    digitalWrite(transistor, LOW);
+    deactivateSDModule();
 }
 
 bool AccessManager::checkAccess(byte *const &detected)

--- a/lib/AccessControl/AccessManager.h
+++ b/lib/AccessControl/AccessManager.h
@@ -5,9 +5,7 @@
 class AccessManager
 {
 public:
-    AccessManager(int sdCSPin, int sdMISOActivatePin);
-
-    void init();
+    void init(int sdCSPin, int sdMISOActivatePin);
     bool checkAccess(byte *const &detected);
     bool writeAccessRecord(byte *const &cardUID);
     void logAccess(byte *const &cardUID, bool accessOrWrite, bool granted);

--- a/lib/AccessControl/RFIDModule.cpp
+++ b/lib/AccessControl/RFIDModule.cpp
@@ -2,12 +2,10 @@
 
 #include <SPI.h>
 
-RFIDModule::RFIDModule(int ssPin, int rstPin) : m_mfrc522(ssPin, rstPin) {}
-
-void RFIDModule::init()
+void RFIDModule::init(int ssPin, int rstPin)
 {
     SPI.begin();
-    m_mfrc522.PCD_Init();
+    m_mfrc522.PCD_Init(ssPin, rstPin);
     m_mfrc522.PCD_SetAntennaGain(m_mfrc522.RxGain_max);
     delay(4);                          // delay to stabilize the module
     m_mfrc522.PCD_DumpVersionToSerial(); // Show details of PCD - MFRC522 Card Reader details

--- a/lib/AccessControl/RFIDModule.h
+++ b/lib/AccessControl/RFIDModule.h
@@ -5,9 +5,7 @@
 class RFIDModule
 {
 public:
-    RFIDModule(int ssPin, int rstPin);
-    
-    void init();
+    void init(int ssPin, int rstPin);
     bool readCardUID(byte *&cardUID);
     bool isNewCardPresent();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
-#include "RFIDModule.h"
-#include "AccessManager.h"
+#include <RFIDModule.h>
+#include <AccessManager.h>
 
 // traffic light LEDs
 constexpr int R_LED_PIN = 4;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,8 +20,8 @@ constexpr int MFRC522_1_SS_PIN = 10;
 constexpr int SD_CS_PIN = 7;
 constexpr int SD_MISO_ACTIVATE_PIN = 8;
 
-RFIDModule rfid(MFRC522_1_SS_PIN, MFRC522_1_RST_PIN);
-AccessManager accessManager(SD_CS_PIN, SD_MISO_ACTIVATE_PIN);
+RFIDModule rfid;
+AccessManager accessManager;
 
 void handleKeyInserted(byte *const &cardUID);
 void entryRoutine(byte *const &cardUID);
@@ -36,8 +36,8 @@ void setup()
     while (!Serial)
         ;
 
-    rfid.init();
-    accessManager.init();
+    rfid.init(MFRC522_1_SS_PIN, MFRC522_1_RST_PIN);
+    accessManager.init(SD_CS_PIN, SD_MISO_ACTIVATE_PIN);
 
     // initialize the pins
     pinMode(R_LED_PIN, OUTPUT);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,9 +85,6 @@ void handleKeyInserted(byte *const &cardUID)
     // try to write the card UID to EEPROM
     bool writeStatus = accessManager.writeAccessRecord(cardUID);
 
-    // log the access attempt
-    accessManager.logAccess(cardUID, true, writeStatus);
-
     if (writeStatus)
         digitalWrite(G_LED_PIN, HIGH); // turn on green LED if successful
     else
@@ -96,15 +93,15 @@ void handleKeyInserted(byte *const &cardUID)
     waitForCardRemoval(); // wait for the card to be removed
     digitalWrite(G_LED_PIN, LOW);
     digitalWrite(R_LED_PIN, LOW);
+
+    // log the access attempt
+    accessManager.logAccess(cardUID, true, writeStatus);
 }
 
 void entryRoutine(byte *const &cardUID)
 {
     // check if the detected card is in the access record
     bool access = accessManager.checkAccess(cardUID);
-
-    // log the access attempt
-    accessManager.logAccess(cardUID, false, access);
 
     if (access)
     {
@@ -118,6 +115,9 @@ void entryRoutine(byte *const &cardUID)
         waitForCardRemoval();
         digitalWrite(R_LED_PIN, LOW);
     }
+
+    // log the access attempt
+    accessManager.logAccess(cardUID, false, access);
 }
 
 void engageLock()


### PR DESCRIPTION
- remove class constructors (they don't work properly)
- move `accessManager.logAccess` calls to the end of `entryRoutine` and `handleKeyInserted` to provide immediate visual feedback